### PR TITLE
Fix core issues and implement missing features

### DIFF
--- a/includes/admin/class-aca-onboarding.php
+++ b/includes/admin/class-aca-onboarding.php
@@ -26,7 +26,7 @@ class ACA_Onboarding {
         add_dashboard_page(
             esc_html__('Welcome to ACA', 'aca-ai-content-agent'),
             null, // Hide from menu
-            'manage_options',
+            'manage_aca_ai_content_agent_settings',
             'aca-ai-content-agent-onboarding',
             [$this, 'render_onboarding_page']
         );

--- a/includes/class-aca-plugin.php
+++ b/includes/class-aca-plugin.php
@@ -99,7 +99,7 @@ class ACA_Plugin {
         // Init classes
         new ACA_Admin_Init();
         new ACA_Ajax_Handler();
-        new ACA_Cron();
+        new ACA_AI_Content_Agent_Cron();
         new ACA_Privacy();
         new ACA_Onboarding();
     }

--- a/includes/services/class-aca-draft-service.php
+++ b/includes/services/class-aca-draft-service.php
@@ -399,6 +399,36 @@ class ACA_Draft_Service {
     }
 
     /**
+     * Provide AI-powered update suggestions for an existing post.
+     */
+    public static function suggest_content_update($post_id) {
+        if ( ! aca_ai_content_agent_is_pro() ) {
+            return new WP_Error('pro_feature', __('This feature is available in the Pro version.', 'aca-ai-content-agent'));
+        }
+
+        $post = get_post( $post_id );
+        if ( ! $post ) {
+            return new WP_Error( 'post_not_found', __('Post not found.', 'aca-ai-content-agent') );
+        }
+
+        $content = wp_strip_all_tags( $post->post_content );
+        $prompt  = sprintf(
+            "Suggest concise improvements to refresh and optimize the following blog post for SEO. Return a bullet list only.\n\nTitle: %s\n\n%s",
+            $post->post_title,
+            $content
+        );
+
+        $response = ACA_Gemini_Api::call( $prompt );
+
+        if ( is_wp_error( $response ) ) {
+            ACA_Log_Service::add( 'Failed to generate update suggestions: ' . $response->get_error_message(), 'error' );
+            return $response;
+        }
+
+        return $response;
+    }
+
+    /**
      * Generate and append a data-backed section with statistics.
      */
     public static function add_data_section($post_id, $title) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, content, generator, automation, content writer,
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0
+Stable tag: 1.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- remove duplicate `reject_idea` method
- implement content cluster generation logic
- add update suggestion handler for posts
- use correct cron class name
- align onboarding capability with plugin roles
- update stable tag to 1.2

## Testing
- `composer install`
- `php -l includes/services/class-aca-idea-service.php`
- `php -l includes/services/class-aca-draft-service.php`
- `php -l includes/class-aca-plugin.php`
- `php -l includes/admin/class-aca-onboarding.php`
- `php -l aca-ai-content-agent.php`


------
https://chatgpt.com/codex/tasks/task_b_6883cadc58b48331841c0ec28a0ae69a