### PR TITLE
Fix missing helper functions causing fatal errors

### DIFF
--- a/aca-ai-content-agent.php
+++ b/aca-ai-content-agent.php
@@ -58,3 +58,45 @@ function aca_ai_content_agent() {
 
 // Global for backwards compatibility.
 $GLOBALS['aca_ai_content_agent'] = aca_ai_content_agent();
+
+/**
+ * Wrapper function to encrypt data using the plugin's utility class.
+ *
+ * This maintains backwards compatibility with earlier versions that
+ * relied on global helper functions.
+ *
+ * @param string $data Plain text data.
+ * @return string Encrypted string.
+ */
+function aca_ai_content_agent_encrypt( $data ) {
+    return ACA_Encryption_Util::encrypt( $data );
+}
+
+/**
+ * Wrapper function to decrypt data.
+ *
+ * @param string $data Encrypted string.
+ * @return string Decrypted value.
+ */
+function aca_ai_content_agent_decrypt( $data ) {
+    return ACA_Encryption_Util::decrypt( $data );
+}
+
+/**
+ * Wrapper to safely decrypt data, falling back to the raw value on failure.
+ *
+ * @param string $data Encrypted or plain string.
+ * @return string Decrypted value or original input.
+ */
+function aca_ai_content_agent_safe_decrypt( $data ) {
+    return ACA_Encryption_Util::safe_decrypt( $data );
+}
+
+/**
+ * Determine if ACA Pro is active.
+ *
+ * @return bool True when the Pro license is valid.
+ */
+function aca_ai_content_agent_is_pro() {
+    return ACA_Helper::is_pro();
+}

--- a/includes/services/class-aca-style-guide-service.php
+++ b/includes/services/class-aca-style-guide-service.php
@@ -95,6 +95,20 @@ class ACA_Style_Guide_Service {
         return $profiles;
     }
 
+    /**
+     * Retrieve stored prompts, falling back to defaults when not set.
+     *
+     * @return array Associative array of prompt templates.
+     */
+    public static function get_prompts() {
+        $defaults = self::get_default_prompts();
+        $stored   = get_option( 'aca_ai_content_agent_prompts', [] );
+        if ( is_array( $stored ) ) {
+            return array_merge( $defaults, array_intersect_key( $stored, $defaults ) );
+        }
+        return $defaults;
+    }
+
     public static function get_default_prompts() {
         return [
             'style_guide'      => "Analyze the following texts. Create a 'Style Guide' that defines the writing tone (e.g., friendly, formal, witty), sentence structure (short, long), paragraph length, and general formatting style (e.g., use of lists, bold text). This guide should be a set of instructions for another writer to imitate this style. The texts are:\n\n%s",


### PR DESCRIPTION
## Summary
- add wrapper functions for encryption and Pro checks
- expose `get_prompts` in style guide service

## Testing
- `php -l aca-ai-content-agent.php`
- `find . -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_b_6883d70a21e08331af7742f1803b3293