### PR TITLE
Add basic error management tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+error-management/error-report.log

--- a/error-management/check-errors.php
+++ b/error-management/check-errors.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Simple syntax error scanner for ACA - AI Content Agent.
+ *
+ * Recursively scans all PHP files under the plugin directory and runs
+ * `php -l` on each file. Any syntax errors are recorded in
+ * `error-management/error-report.log`.
+ */
+
+$pluginDir = dirname(__DIR__);
+$iterator  = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($pluginDir)
+);
+
+$errors = [];
+foreach ($iterator as $file) {
+    if ($file->isFile() && $file->getExtension() === 'php') {
+        $command = 'php -l ' . escapeshellarg($file->getPathname()) . ' 2>&1';
+        $output  = shell_exec($command);
+        if ($output === null) {
+            $errors[$file->getPathname()] = 'Failed to execute php -l';
+        } elseif (strpos($output, 'No syntax errors detected') === false) {
+            $errors[$file->getPathname()] = trim($output);
+        }
+    }
+}
+
+$logFile = __DIR__ . '/error-report.log';
+$logHandle = fopen($logFile, 'w');
+foreach ($errors as $path => $message) {
+    fwrite($logHandle, $path . "\n" . $message . "\n\n");
+}
+
+fclose($logHandle);
+
+if (empty($errors)) {
+    echo "No syntax errors detected.\n";
+} else {
+    echo "Syntax errors found in " . count($errors) . " file(s).\n";
+    echo "Details written to {$logFile}\n";
+}

--- a/error-management/class-aca-error-manager.php
+++ b/error-management/class-aca-error-manager.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ACA_Error_Manager
+ *
+ * Sets custom handlers to capture PHP errors and exceptions. Any captured
+ * messages are logged via ACA_Log_Service for later inspection.
+ *
+ * @package ACA_AI_Content_Agent\Error_Management
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class ACA_Error_Manager {
+
+    /**
+     * Register handlers for errors and exceptions.
+     */
+    public static function init() {
+        set_error_handler( [ __CLASS__, 'handle_error' ] );
+        set_exception_handler( [ __CLASS__, 'handle_exception' ] );
+        register_shutdown_function( [ __CLASS__, 'handle_shutdown' ] );
+    }
+
+    /**
+     * Handle standard PHP errors.
+     */
+    public static function handle_error( $errno, $errstr, $errfile, $errline ) {
+        $message = sprintf( '%s in %s on line %d', $errstr, $errfile, $errline );
+        ACA_Log_Service::add( $message, 'error' );
+        return false; // Execute PHP internal error handler as well.
+    }
+
+    /**
+     * Handle uncaught exceptions.
+     */
+    public static function handle_exception( $exception ) {
+        $message = sprintf( 'Uncaught exception %s: %s in %s on line %d',
+            get_class( $exception ),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
+        ACA_Log_Service::add( $message, 'error' );
+    }
+
+    /**
+     * Handle shutdown and catch fatal errors.
+     */
+    public static function handle_shutdown() {
+        $error = error_get_last();
+        if ( $error && in_array( $error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR ] ) ) {
+            $message = sprintf( '%s in %s on line %d', $error['message'], $error['file'], $error['line'] );
+            ACA_Log_Service::add( $message, 'error' );
+        }
+    }
+}

--- a/includes/class-aca-plugin.php
+++ b/includes/class-aca-plugin.php
@@ -80,6 +80,9 @@ class ACA_Plugin {
         require_once plugin_dir_path( __FILE__ ) . '/utils/class-aca-helper.php';
         require_once plugin_dir_path( __FILE__ ) . '/utils/class-aca-log-service.php';
 
+        // Error management
+        require_once ACA_AI_CONTENT_AGENT_PLUGIN_DIR . 'error-management/class-aca-error-manager.php';
+
         // Cron
         require_once plugin_dir_path( __FILE__ ) . '/class-aca-cron.php';
     }
@@ -102,5 +105,8 @@ class ACA_Plugin {
         new ACA_AI_Content_Agent_Cron();
         new ACA_Privacy();
         new ACA_Onboarding();
+
+        // Start error management
+        ACA_Error_Manager::init();
     }
 }


### PR DESCRIPTION
## Summary
- add a simple error scanner script in `error-management`
- log any runtime PHP errors through a new `ACA_Error_Manager` class
- include the error manager when the plugin loads
- ignore generated error reports

## Testing
- `composer install`
- `php error-management/check-errors.php`

------
https://chatgpt.com/codex/tasks/task_b_6883e99deb448331a0039fa86f1ead1e