### PR TITLE
Initialize Vk library

### DIFF
--- a/ai-content-agent-plugin/App.tsx
+++ b/ai-content-agent-plugin/App.tsx
@@ -58,6 +58,37 @@ const App: React.FC = () => {
     const drafts = posts.filter(p => p.status === 'draft');
     const publishedPosts = posts.filter(p => p.status === 'published');
 
+    const addToast = useCallback((toast: Omit<ToastData, 'id'>) => {
+        const id = Date.now();
+        setToasts(prev => [...prev, { ...toast, id }]);
+    }, []);
+
+    const showToast = useCallback((message: string, type: 'success' | 'error' | 'warning' | 'info') => {
+        addToast({ message, type });
+    }, [addToast]);
+
+    const removeToast = useCallback((id: number) => {
+        setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id));
+    }, []);
+    
+    const addLogEntry = useCallback((type: ActivityLogType, details: string, icon: IconName) => {
+        const newLog: ActivityLog = {
+            id: Date.now(),
+            type,
+            details,
+            timestamp: new Date().toISOString(),
+            icon
+        };
+        setActivityLogs(prev => [newLog, ...prev.slice(0, 49)]);
+        
+        // Save to WordPress with correct parameter names
+        activityApi.create({
+            type,
+            message: details,
+            icon
+        }).catch(console.error);
+    }, []);
+
     useEffect(() => {
         // Check if WordPress localized data is available
         if (!window.acaData) {
@@ -111,38 +142,7 @@ const App: React.FC = () => {
         };
         
         loadInitialData();
-    }, []);
-
-    const addToast = useCallback((toast: Omit<ToastData, 'id'>) => {
-        const id = Date.now();
-        setToasts(prev => [...prev, { ...toast, id }]);
-    }, []);
-
-    const showToast = useCallback((message: string, type: 'success' | 'error' | 'warning' | 'info') => {
-        addToast({ message, type });
     }, [addToast]);
-    
-    const addLogEntry = useCallback((type: ActivityLogType, details: string, icon: IconName) => {
-        const newLog: ActivityLog = {
-            id: Date.now(),
-            type,
-            details,
-            timestamp: new Date().toISOString(),
-            icon
-        };
-        setActivityLogs(prev => [newLog, ...prev.slice(0, 49)]);
-        
-        // Save to WordPress with correct parameter names
-        activityApi.create({
-            type,
-            message: details,
-            icon
-        }).catch(console.error);
-    }, []);
-
-    const removeToast = useCallback((id: number) => {
-        setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id));
-    }, []);
 
     const handleAnalyzeStyle = useCallback(async (showToast = true) => {
         setIsLoading(prev => ({ ...prev, style: true }));


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Reorder React hook definitions to resolve a `useEffect` dependency issue.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `showToast` function was being called within a `useEffect` hook before its `useCallback` definition, leading to a reference error in the minified code. Reordering ensures all callback functions are defined before being used by `useEffect`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e965aa4e-e7c8-432c-a028-38bd6f1b7d5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e965aa4e-e7c8-432c-a028-38bd6f1b7d5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>