### PR TITLE
Review settings page jumping issue and document fix

### DIFF
--- a/Jumperor.md
+++ b/Jumperor.md
@@ -1,0 +1,463 @@
+# Jumperor.md - Settings Page Jump Issue Analysis & Full Page Navigation Solution
+
+## Project Overview
+**Plugin**: AI Content Agent (ACA)  
+**Issue**: Settings page jumping when CollapsibleSection elements are opened  
+**Current Version**: 2.3.2 (based on changelog)  
+**Analysis Date**: January 31, 2025
+
+## Issue History Analysis
+
+### Previous Fix Attempts (from Changelog)
+Based on the changelog analysis, this issue has been addressed multiple times:
+
+1. **v2.3.2** - "CRITICAL FIX: Settings Page Scroll Jumping (FINAL SOLUTION)"
+   - Root cause identified: JavaScript targeting wrong DOM element
+   - CSS: Scroll container is `#root` element (`overflow-y: auto !important`)
+   - JavaScript: Was targeting `.aca-main` element (which has no scroll)
+   - Solution: Direct targeting of `#root` element with scroll position preservation
+
+2. **v2.3.1** - "Settings Page Scroll Jumping Fix (ENHANCED)"
+   - Enhanced JavaScript-based scroll position preservation
+   - Double requestAnimationFrame for better timing
+   - Multiple container detection fallbacks
+
+3. **v2.2.6** - "CRITICAL SETTINGS PAGE SCROLL JUMPING FIX"
+   - CSS container stabilization with fixed height containers
+   - Dropdown height limiting to 500px with internal scrolling
+   - Scroll position preservation during animations
+
+4. **v2.2.4** - "Settings Page Dropdown Jumping Fix"
+   - Replaced `scaleY` transform with `max-height` transition
+   - Eliminated page jumping when opening Settings dropdown sections
+
+**Conclusion**: Despite multiple fix attempts, the issue persists, indicating a fundamental architectural problem.
+
+## Current Architecture Analysis
+
+### 1. View Management System (`App.tsx`)
+```typescript
+// Current view types (lines 1-2 of types.ts)
+export type View = 'dashboard' | 'style-guide' | 'ideas' | 'drafts' | 'published' | 'settings' | 'calendar' | 'content-freshness';
+
+// App component manages single view state (line 32)
+const [view, setView] = useState<View>('dashboard');
+
+// View rendering function (lines 499-571)
+const renderView = () => {
+    switch (view) {
+        case 'settings':
+            return <Settings 
+                settings={settings} 
+                onSaveSettings={handleSaveSettings} 
+                onRefreshApp={handleRefreshApp} 
+                onShowToast={showToast} 
+                openSection={settingsOpenSection}
+            />;
+        // ... other cases
+    }
+};
+```
+
+### 2. Sidebar Navigation (`Sidebar.tsx`)
+```typescript
+// Current navigation structure (lines 172-282)
+// Single-level navigation with direct view switching
+<NavItem 
+    icon={<Settings />} 
+    label="Settings" 
+    view="settings" 
+    currentView={currentView} 
+    onClick={() => handleNavigation('settings')} 
+/>
+```
+
+### 3. Settings Component Structure (`Settings.tsx`)
+**Size**: 1,761 lines - MASSIVE single component  
+**Structure**: Monolithic component with multiple CollapsibleSection elements
+
+```typescript
+// Current problematic structure
+<CollapsibleSection id="license" title="Pro License Activation" ... />
+<CollapsibleSection id="automation" title="Automation Mode" ... />
+<CollapsibleSection id="integrations" title="Integrations & Services" ... />
+<CollapsibleSection id="content" title="Content & SEO Settings" ... />
+<CollapsibleSection id="advanced" title="Advanced Settings" ... />
+```
+
+**Issues Identified**:
+1. **Massive single component** (1,761 lines) handling all settings
+2. **Dynamic height changes** when CollapsibleSections expand/collapse
+3. **Complex scroll management** with multiple nested elements
+4. **State management complexity** with all settings in one component
+
+### 4. CollapsibleSection Implementation
+**CRITICAL FINDING**: The CollapsibleSection component is used extensively in Settings.tsx (lines 636, 739, 946, 1598, 1627) but **is not defined anywhere in the codebase**. This suggests:
+
+1. **Missing Component**: The component definition is missing, which would cause React errors
+2. **Incomplete Refactoring**: Previous attempts to fix the jumping issue may have removed the component without proper replacement
+3. **Build Issues**: The current code likely doesn't compile properly due to undefined component
+
+**Evidence from CSS**: The CSS file contains specific styles for collapsible sections (lines 1073-1106) including:
+- `body.toplevel_page_ai-content-agent .aca-card [id^="section-content-"]` - targeting section content
+- Transition optimizations and layout shift prevention
+- Scroll behavior modifications with `.no-smooth-scroll` class
+
+This confirms that CollapsibleSection was previously implemented but has been removed, likely during one of the multiple fix attempts documented in the changelog.
+
+## Current State Analysis
+
+### Broken Implementation Status
+**CRITICAL ISSUE**: The current Settings.tsx file is in a **broken state** and likely **non-functional**:
+
+1. **Undefined Component Usage**: 5 instances of `<CollapsibleSection>` without definition
+2. **Compilation Errors**: TypeScript/React would throw errors for undefined component
+3. **Runtime Failures**: If somehow compiled, would crash at runtime
+4. **Inconsistent State**: CSS exists for removed component, indicating incomplete refactoring
+
+### How Current Code Would Behave
+If the current code were to run (which it shouldn't compile), the Settings page would:
+- Display the header section correctly (lines 564-634)
+- **Crash or show errors** when encountering the first `<CollapsibleSection>` (line 637)
+- Never render the actual settings content (license, automation, integrations, etc.)
+
+### Evidence of Previous Fix Attempts
+The CSS file shows remnants of sophisticated scroll management attempts:
+```css
+/* From lines 1070-1072 */
+body.toplevel_page_ai-content-agent #root.no-smooth-scroll {
+  scroll-behavior: auto !important;
+}
+
+/* From lines 1073-1081 - Collapsible section optimizations */
+body.toplevel_page_ai-content-agent .aca-card [id^="section-content-"] {
+  transform-origin: top !important;
+  backface-visibility: hidden !important;
+  will-change: transform, opacity !important;
+  contain: layout style paint !important;
+}
+```
+
+This indicates that previous developers attempted multiple sophisticated solutions including:
+- Scroll behavior control
+- Transform optimizations
+- Layout containment
+- Backface visibility management
+
+### Why Previous Fixes Failed
+The multiple fix attempts failed because they were trying to solve a **fundamental architectural problem** with technical workarounds:
+1. **Dynamic height changes** are inherent to collapsible sections
+2. **Scroll position management** becomes complex with nested containers
+3. **CSS animations** inevitably cause layout shifts during transitions
+4. **State management** becomes unwieldy in a 1,761-line component
+
+## Root Cause Analysis
+
+### Technical Root Cause
+1. **Dynamic Height Changes**: When CollapsibleSection elements expand, they change the overall page height
+2. **Scroll Container Confusion**: Multiple scroll containers (`#root`, `.aca-main`) cause targeting issues
+3. **CSS Animation Conflicts**: `max-height` transitions and other animations affect layout during state changes
+4. **Monolithic Component**: Single massive Settings component makes scroll management complex
+
+### Architectural Root Cause
+The current architecture treats Settings as a single page with expandable sections, but this creates inherent scroll management problems when content dynamically changes height.
+
+## Proposed Solution: Full Page Navigation Model
+
+### Overview
+Transform the Settings section from a single page with collapsible sections into multiple separate pages, similar to the existing view management system.
+
+### Implementation Strategy
+
+#### 1. Extend Type Definitions (`types.ts`)
+```typescript
+// Current (line 2)
+export type View = 'dashboard' | 'style-guide' | 'ideas' | 'drafts' | 'published' | 'settings' | 'calendar' | 'content-freshness';
+
+// Proposed
+export type View = 'dashboard' | 'style-guide' | 'ideas' | 'drafts' | 'published' | 'settings' | 'calendar' | 'content-freshness' | 'settings_license' | 'settings_automation' | 'settings_integrations' | 'settings_content' | 'settings_advanced';
+```
+
+#### 2. Update Sidebar Navigation (`Sidebar.tsx`)
+Transform the Settings navigation into a hierarchical structure:
+
+```typescript
+// Current single Settings item (lines 275-281)
+<NavItem 
+    icon={<Settings />} 
+    label="Settings" 
+    view="settings" 
+    currentView={currentView} 
+    onClick={() => handleNavigation('settings')} 
+/>
+
+// Proposed hierarchical structure
+<div style={{ marginBottom: '24px' }}>
+    <div style={{ 
+        fontSize: '11px', 
+        fontWeight: '600', 
+        color: '#94a3b8', 
+        textTransform: 'uppercase', 
+        letterSpacing: '0.5px',
+        marginBottom: '8px',
+        paddingLeft: '16px'
+    }}>
+        Settings
+    </div>
+    <NavItem 
+        icon={<Shield />} 
+        label="License" 
+        view="settings_license" 
+        currentView={currentView} 
+        onClick={() => handleNavigation('settings_license')} 
+    />
+    <NavItem 
+        icon={<Zap />} 
+        label="Automation" 
+        view="settings_automation" 
+        currentView={currentView} 
+        onClick={() => handleNavigation('settings_automation')} 
+    />
+    <NavItem 
+        icon={<Settings />} 
+        label="Integrations" 
+        view="settings_integrations" 
+        currentView={currentView} 
+        onClick={() => handleNavigation('settings_integrations')} 
+    />
+    <NavItem 
+        icon={<Image />} 
+        label="Content & SEO" 
+        view="settings_content" 
+        currentView={currentView} 
+        onClick={() => handleNavigation('settings_content')} 
+    />
+    <NavItem 
+        icon={<Settings />} 
+        label="Advanced" 
+        view="settings_advanced" 
+        currentView={currentView} 
+        onClick={() => handleNavigation('settings_advanced')} 
+    />
+</div>
+```
+
+#### 3. Update App Component (`App.tsx`)
+Add new view cases to the renderView function (around line 500):
+
+```typescript
+const renderView = () => {
+    switch (view) {
+        // ... existing cases
+        case 'settings':
+            // Redirect to license page or show overview
+            return <SettingsLicense settings={settings} onSaveSettings={handleSaveSettings} onRefreshApp={handleRefreshApp} onShowToast={showToast} />;
+        case 'settings_license':
+            return <SettingsLicense settings={settings} onSaveSettings={handleSaveSettings} onRefreshApp={handleRefreshApp} onShowToast={showToast} />;
+        case 'settings_automation':
+            return <SettingsAutomation settings={settings} onSaveSettings={handleSaveSettings} onShowToast={showToast} />;
+        case 'settings_integrations':
+            return <SettingsIntegrations settings={settings} onSaveSettings={handleSaveSettings} onShowToast={showToast} />;
+        case 'settings_content':
+            return <SettingsContent settings={settings} onSaveSettings={handleSaveSettings} onShowToast={showToast} />;
+        case 'settings_advanced':
+            return <SettingsAdvanced settings={settings} onSaveSettings={handleSaveSettings} onShowToast={showToast} />;
+        // ... other cases
+    }
+};
+```
+
+#### 4. Break Down Settings Component
+Split the massive 1,761-line `Settings.tsx` into separate components:
+
+**New Components to Create**:
+1. `SettingsLicense.tsx` - Pro license activation (lines 636-737)
+2. `SettingsAutomation.tsx` - Automation mode configuration (lines 740-944)
+3. `SettingsIntegrations.tsx` - External services integration (lines 947-1596)
+4. `SettingsContent.tsx` - Content analysis settings (lines 1599-1625)
+5. `SettingsAdvanced.tsx` - Debug panel and advanced settings (lines 1628-1719)
+
+**Shared Components**:
+- Extract common elements like `RadioCard`, `IntegrationCard` into separate files
+- Create shared settings utilities and hooks
+
+### Benefits of This Approach
+
+#### 1. Eliminates Jumping Issue
+- **Static Page Heights**: Each settings page has a fixed height, no dynamic expansion
+- **No CollapsibleSections**: Eliminates the root cause of scroll jumping
+- **Simplified Scroll Management**: Each page manages its own scroll independently
+
+#### 2. Improved User Experience
+- **Familiar Navigation Pattern**: Similar to WordPress admin, dashboard navigation
+- **Faster Loading**: Only load relevant settings page
+- **Better Focus**: Users focus on one settings category at a time
+- **URL Support**: Each settings page can have direct URLs
+
+#### 3. Better Code Architecture
+- **Separation of Concerns**: Each component handles one settings category
+- **Maintainability**: Smaller, focused components are easier to maintain
+- **Reusability**: Common components can be shared across settings pages
+- **Testing**: Easier to unit test individual settings components
+
+#### 4. Development Benefits
+- **Parallel Development**: Multiple developers can work on different settings pages
+- **Easier Debugging**: Issues isolated to specific components
+- **Performance**: Lazy loading of settings components
+- **Scalability**: Easy to add new settings categories
+
+### Implementation Phases
+
+#### Phase 1: Infrastructure Setup
+1. Update `types.ts` with new view types
+2. Update `App.tsx` renderView function
+3. Create shared settings components and utilities
+
+#### Phase 2: Component Extraction
+1. Extract `SettingsLicense.tsx` from existing Settings component
+2. Extract `SettingsAutomation.tsx` 
+3. Extract `SettingsIntegrations.tsx`
+4. Extract `SettingsContent.tsx`
+5. Extract `SettingsAdvanced.tsx`
+
+#### Phase 3: Navigation Update
+1. Update `Sidebar.tsx` with hierarchical settings navigation
+2. Implement navigation state management
+3. Add URL routing support (optional)
+
+#### Phase 4: Testing & Refinement
+1. Test all settings pages individually
+2. Test navigation between settings pages
+3. Verify no jumping issues
+4. Performance optimization
+
+### Potential Challenges & Solutions
+
+#### Challenge 1: Shared State Management
+**Issue**: Settings state needs to be shared across multiple components
+**Solution**: 
+- Keep settings state in App component
+- Pass settings and handlers as props to each settings component
+- Consider using React Context for complex scenarios
+
+#### Challenge 2: Save Button Behavior
+**Issue**: Current save button saves all settings at once
+**Solution**:
+- Implement per-page save functionality
+- Add global "unsaved changes" detection
+- Provide save confirmation when navigating between pages
+
+#### Challenge 3: Deep Linking
+**Issue**: Users might want to link directly to specific settings
+**Solution**:
+- Implement URL-based routing for settings pages
+- Add navigation state persistence
+- Support opening specific sections via URL parameters
+
+#### Challenge 4: Mobile Navigation
+**Issue**: Hierarchical navigation might be complex on mobile
+**Solution**:
+- Implement responsive navigation patterns
+- Consider breadcrumb navigation
+- Use mobile-friendly menu structures
+
+## Current Settings Component Breakdown
+
+### Section Analysis (from Settings.tsx)
+
+#### 1. License Section (lines 636-737)
+- **Size**: ~100 lines
+- **Complexity**: Medium (license verification, state management)
+- **Dependencies**: `licenseApi`, toast notifications
+- **UI Elements**: Input field, buttons, status display
+
+#### 2. Automation Section (lines 740-944)
+- **Size**: ~200 lines
+- **Complexity**: High (nested conditional rendering, multiple form elements)
+- **Dependencies**: Pro license status, multiple settings
+- **UI Elements**: Radio cards, dropdowns, checkboxes, conditional sections
+
+#### 3. Integrations Section (lines 947-1596)
+- **Size**: ~650 lines (LARGEST)
+- **Complexity**: Very High (multiple integrations, complex UI)
+- **Dependencies**: Multiple APIs, SEO plugins, GSC integration
+- **UI Elements**: Multiple integration cards, forms, status displays
+
+#### 4. Content Section (lines 1599-1625)
+- **Size**: ~25 lines
+- **Complexity**: Low (single dropdown)
+- **Dependencies**: Settings state
+- **UI Elements**: Single dropdown selection
+
+#### 5. Advanced Section (lines 1628-1719)
+- **Size**: ~90 lines
+- **Complexity**: Medium (debug functions, API calls)
+- **Dependencies**: WordPress API, debug endpoints
+- **UI Elements**: Buttons, status displays
+
+## Conclusion
+
+### Immediate Priority: Fix Broken Implementation
+**URGENT**: The current Settings page is completely broken due to missing CollapsibleSection component. This must be addressed immediately before any architectural improvements.
+
+### Long-term Solution: Full Page Navigation Model
+The Full Page Navigation Model is the optimal solution for the persistent jumping issue because:
+
+1. **Addresses Root Cause**: Eliminates dynamic height changes that cause jumping
+2. **Fixes Broken State**: Replaces the missing CollapsibleSection with a working architecture
+3. **Improves Architecture**: Breaks down monolithic component into manageable pieces
+4. **Enhances User Experience**: Provides familiar navigation patterns
+5. **Enables Future Growth**: Scalable architecture for adding new settings
+6. **Simplifies Maintenance**: Easier to debug, test, and maintain individual components
+7. **Prevents Future Issues**: Eliminates the need for complex scroll management workarounds
+
+### Why This Approach is Superior to Previous Attempts
+Unlike previous fixes that tried to solve the jumping issue with:
+- Complex CSS animations and transforms
+- Sophisticated scroll position management
+- Layout containment and optimization tricks
+- JavaScript-based scroll preservation
+
+The Full Page Navigation Model **eliminates the problem entirely** by removing the need for:
+- Dynamic height changes (no collapsible sections)
+- Complex scroll management (each page has static height)
+- Animation-based transitions (simple page navigation)
+- Monolithic component state management
+
+The solution aligns with existing patterns in the codebase (view management system) and provides a long-term architectural improvement rather than another temporary fix.
+
+## Next Steps
+
+### Immediate Actions (URGENT)
+1. **Fix Broken Settings Page**: The current implementation is completely non-functional
+   - Either restore the missing CollapsibleSection component as a temporary fix
+   - Or immediately begin Full Page Navigation Model implementation
+   - **Priority**: HIGH - Settings page is currently unusable
+
+### Implementation Phases (After Immediate Fix)
+1. **Phase 1 - Infrastructure Setup**: Update type definitions and infrastructure
+2. **Phase 2 - Component Extraction**: Break down Settings.tsx into separate components
+3. **Phase 3 - Navigation Update**: Implement hierarchical settings navigation
+4. **Phase 4 - Testing & Refinement**: Verify no jumping issues and proper functionality
+
+### Alternative Immediate Solutions
+If Full Page Navigation Model cannot be implemented immediately:
+
+**Option A - Temporary CollapsibleSection Restoration**:
+- Create a simple CollapsibleSection component to restore functionality
+- Use basic show/hide without animations to prevent jumping
+- Plan for future architectural improvement
+
+**Option B - Simple Accordion Implementation**:
+- Replace CollapsibleSection with basic HTML details/summary elements
+- No JavaScript animations, just browser-native expand/collapse
+- Minimal jumping risk with native implementation
+
+### Recommendation
+**Implement Full Page Navigation Model immediately** rather than temporary fixes, because:
+1. Current code is already broken and needs major changes
+2. Temporary fixes will perpetuate the architectural problems
+3. The effort to implement temporary fixes is nearly equal to implementing the proper solution
+4. Users are already experiencing a broken settings page
+
+This approach will finally resolve the jumping issue that has persisted through multiple versions while significantly improving the codebase architecture and user experience.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Create `Jumperor.md` to document a comprehensive analysis of the settings page jumping issue and propose a full page navigation solution.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This document details a thorough investigation into the persistent settings page jumping issue, which has been attempted to be fixed across multiple versions. It identifies that the current `Settings.tsx` is critically broken due to the use of an undefined `CollapsibleSection` component. The document proposes a 'Full Page Navigation Model' as a robust, long-term architectural solution to both the jumping issue and the current broken state, serving as a blueprint for future implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d1015c5-3a36-4c58-94bc-04349e1c7df5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d1015c5-3a36-4c58-94bc-04349e1c7df5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>